### PR TITLE
MakeTimeClub header links to root index

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <header class="mainHeader" role="banner">
     <div class="constrained">
-        <div class="pageTitle"><a href="{{ site.baseurl }}"><span class="make">Make</span> <span class="time">Time</span> <span class="club">Club</span></a></div>
+        <div class="pageTitle"><a href="/"><span class="make">Make</span> <span class="time">Time</span> <span class="club">Club</span></a></div>
     </div>
 </header>


### PR DESCRIPTION
A modest proposal to change this URL to be the root index, so that clicking the header text will link you back to the home page.

I think baseurl is used for some a different case: https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/
